### PR TITLE
Tune VQF constants for low-noise sensors

### DIFF
--- a/src/sensor/fusion/vqf/vqf.c
+++ b/src/sensor/fusion/vqf/vqf.c
@@ -45,11 +45,10 @@ void vqf_update_sensor_ids(int imu)
 	imu_id = imu;
 }
 
-static void set_params()
-{
+static void set_params() {
 	init_params(&params);
 	params.biasClip = 5.0f;
-	params.tauMag = 10.0f; // best result for VQF from paper
+	params.tauMag = 5.0f;  // reduced for stable magnetic field
 	// best result from optimizer
 	params.biasForgettingTime = 136.579346;
 	params.biasSigmaInit = 3.219453;
@@ -58,11 +57,11 @@ static void set_params()
 	params.biasVerticalForgettingFactor = 0.007056;
 	params.motionBiasEstEnabled = true;
 	params.restBiasEstEnabled = true;
-	params.restFilterTau = 1.114532;
+	params.restFilterTau = 0.5f;
 	params.restMinT = 2.586910;
 	params.restThAcc = 1.418598;
 	params.restThGyr = 1.399189;
-	params.tauAcc = 4.337983;
+	params.tauAcc = 2.0f;  // faster response with low accelerometer noise
 }
 
 void vqf_init(float g_time, float a_time, float m_time)


### PR DESCRIPTION
## Summary
- shorten VQF accel time constant for faster gravity correction
- lower magnetic filter tau for stable field
- quick rest detection with shorter filter tau
