### PR TITLE
Integrate VQF rest bias into zero calibration

### DIFF
--- a/src/sensor/calibration.h
+++ b/src/sensor/calibration.h
@@ -36,7 +36,13 @@ uint8_t* sensor_calibration_get_sensor_data();
 
 void sensor_calibration_read(void);
 
+void sensor_calibration_get_gyro_bias(float bias[3]);
+
 int sensor_calibration_validate(float* a_bias, float* g_bias, bool write);
+bool sensor_calibration_integrate_runtime_gyro_bias(
+	const float delta[3],
+	float applied[3]
+);
 #if CONFIG_SENSOR_USE_6_SIDE_CALIBRATION
 int sensor_calibration_validate_6_side(float a_inv[][3], bool write);
 #endif


### PR DESCRIPTION
## Summary
- reset the calibration runtime gyro accumulator on load and expose a getter so fusion can compare stored bias
- harvest VQF rest periods to feed the fusion bias estimate back into the persisted zero calibration while clamping updates
- revert prior xioFusion runtime bias experiments since the build targets use VQF exclusively

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58149c7e4832b87b2d68029d9d06b